### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
 
   def index
-    @items = Item.includes(:user).order("created_at DESC")
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new
@@ -24,5 +24,4 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:name, :description, :category_id, :condition_id, :fee_id, :prefecture_id, :day_id, :price,
                                  :image).merge(user_id: current_user.id)
   end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,9 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
 
-# def index
-#    @items = Item.includes(:user)
-#  end
+  def index
+    @items = Item.includes(:user).order("created_at DESC")
+  end
 
   def new
     @item = Item.new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -124,56 +124,54 @@
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
+    
     <ul class='item-lists'>
-
-      <% @items.each do |item| %>
-      <li class='list'>
-        <%= link_to image_tag(item.image) do %>
-        <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" %>
-
-          <% if @item == false %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+      <% if @items != [] %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to image_tag(item.image) do %>
+              <div class='item-img-content'>
+                <%= image_tag item.image, class: "item-img" %>
+                <%# if @item == false %>
+                  <div class='sold-out'>
+                    <span>Sold Out!!</span>
+                  </div>
+                <%# end %>
+              </div>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= item.name %>
+                </h3>
+                <div class='item-price'>
+                  <span><%= item.price %>円<br><%= item.fee[:name] %></span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </li>
+        <% end%>
+      <%else%>
+        <li class='list'>
+          <%= link_to '#' do %>
+            <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                商品を出品してね！
+              </h3>
+              <div class='item-price'>
+                <span>99999999円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
           <% end %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= item.name %>
-          </h3>
-          <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.fee[:name] %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <% end%>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
+        </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,24 +127,27 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to image_tag(item.image) do %>
         <div class='item-img-content'>
           <%= image_tag "item-sample.png", class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
+          <% if @item == false %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
+          <% end %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.fee %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,6 +156,7 @@
         </div>
         <% end %>
       </li>
+      <% end%>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,20 +126,17 @@
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
       <li class='list'>
         <%= link_to image_tag(item.image) do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
           <% if @item == false %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <% end %>
-          <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
@@ -147,7 +144,7 @@
             <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.fee %></span>
+            <span><%= item.price %>円<br><%= item.fee[:name] %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -157,7 +154,6 @@
         <% end %>
       </li>
       <% end%>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -99,33 +99,33 @@ RSpec.describe Item, type: :model do
         end
 
         it 'priceが半角英数混合では登録できないこと' do
-          @item.price = "11aa"
+          @item.price = '11aa'
           @item.valid?
-          expect(@item.errors.full_messages).to include("Price 半角数字を使用してください")
+          expect(@item.errors.full_messages).to include('Price 半角数字を使用してください')
         end
 
         it 'priceが半角英語だけでは登録できないこと' do
-          @item.price = "aaaa"
+          @item.price = 'aaaa'
           @item.valid?
-          expect(@item.errors.full_messages).to include("Price 半角数字を使用してください")
+          expect(@item.errors.full_messages).to include('Price 半角数字を使用してください')
         end
 
         it 'priceが全角英語では登録できないこと' do
-          @item.price = "ａａａａ"
+          @item.price = 'ａａａａ'
           @item.valid?
-          expect(@item.errors.full_messages).to include("Price 半角数字を使用してください")
+          expect(@item.errors.full_messages).to include('Price 半角数字を使用してください')
         end
 
         it 'priceが299円以下では登録できないこと' do
           @item.price = 299
           @item.valid?
-          expect(@item.errors.full_messages).to include("Price ¥300~¥9,999,999の間で入力してください")
+          expect(@item.errors.full_messages).to include('Price ¥300~¥9,999,999の間で入力してください')
         end
 
         it 'priceが10000000円以上では登録できないこと' do
-          @item.price = 10000000
+          @item.price = 10_000_000
           @item.valid?
-          expect(@item.errors.full_messages).to include("Price ¥300~¥9,999,999の間で入力してください")
+          expect(@item.errors.full_messages).to include('Price ¥300~¥9,999,999の間で入力してください')
         end
 
         it 'userが紐づいてないと登録できないこと' do


### PR DESCRIPTION
# What
商品一覧表示機能を実装しました。

# Why
商品を一覧に表示することで、ユーザーが見やすいようにしました。

出品した商品の一覧表示ができている
出品された日時が新しい順に表示
「画像/価格/商品名」の3つの情報について表示できている
https://gyazo.com/17bfb02d3b0b056a2aa41fa6c2d7a224
ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
https://gyazo.com/b14669940003afec71799e0dd0fe38d4